### PR TITLE
Fix: gocui.Gui has no field or method Execute

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ func main() {
 	}
 	defer g.Close()
 
-	state.ExecuteFunc = g.Execute
+	state.ExecuteFunc = g.Update
 
 	g.SetManagerFunc(layout)
 	g.Cursor = true


### PR DESCRIPTION
gocui renamed `Execute` to `Update` which broke claws:

```
main.go:23: g.Execute undefined (type *gocui.Gui has no field or method Execute)
```

https://github.com/jroimartin/gocui/commit/6564cfcacb01db61e3a4e983405a598db3e91982#diff-55fd5f4372d25ad4c5728e1929d81bc4